### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To manage the different screens for our game we have multiple options, we will s
 On our game loop (Update/Draw) we will just check for current game state and we will Update/Draw required data.
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [core_basic_window](http://www.raylib.com/examples/web/core/loader.html?name=core_basic_window) - simple code showing a videogame life cycle
+ - [core_basic_window](http://www.raylib.com/examples/core/loader.html?name=core_basic_window) - simple code showing a videogame life cycle
  - [core_basic_screen_manager](https://github.com/raysan5/raylib/blob/master/examples/core/core_basic_screen_manager.c) - basic screens management structure
  
 
@@ -112,8 +112,8 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color);
 Most of those functions are self explanatory, they must be called in the draw part of the game loop, between `BeginDrawing()` and `EndDrawing()`. User needs to provide the drawing position (x, y), size and color. Just note that in case of rectangle-shapes drawing origin is upper-left corner while drawing circle-shapes origin is set in the center of the circle.
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [shapes_basic_shapes](http://www.raylib.com/examples/web/shapes/loader.html?name=shapes_basic_shapes) - basic shapes drawing
- - [shapes_logo_raylib](http://www.raylib.com/examples/web/shapes/loader.html?name=shapes_logo_raylib) - raylib logo drawn using shapes
+ - [shapes_basic_shapes](http://www.raylib.com/examples/shapes/loader.html?name=shapes_basic_shapes) - basic shapes drawing
+ - [shapes_logo_raylib](http://www.raylib.com/examples/shapes/loader.html?name=shapes_logo_raylib) - raylib logo drawn using shapes
 
 
 ### Lesson 03: Inputs management (keyboard, mouse)
@@ -138,8 +138,8 @@ Vector2 GetMousePosition(void);           // Returns mouse position XY
 This set of functions can be used in the `update` part of the game loop to check **if** one key or button has been pressed (or is being pressed in that frame).  
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [core_input_keys](http://www.raylib.com/examples/web/core/loader.html?name=core_input_keys) - keyboard inputs check
- - [core_input_mouse](http://www.raylib.com/examples/web/core/loader.html?name=core_input_mouse) - mouse inputs check
+ - [core_input_keys](http://www.raylib.com/examples/core/loader.html?name=core_input_keys) - keyboard inputs check
+ - [core_input_mouse](http://www.raylib.com/examples/core/loader.html?name=core_input_mouse) - mouse inputs check
 
 
 ### Lesson 04: Collision detection and resolution
@@ -167,7 +167,7 @@ Second, that image data must be uploaded to VRAM memory (GPU) to be used on scre
 
 Third, when drawing a texture to screen, texture is actually pasted over a quad (two triangles structure) and processed to display on the screen; that processing occurs in a per-fragment basis... think about it like a per pixel or sub-pixel processing, placing every fragment on the final canvas.
 
-raylib provides multiple functions to deal with textures an images, depending on the intended use of the data, user can choose the right one; for example, most of the time, images will be loaded as textures to be displayed on screen but image data can also be used to generate 3d models, like in the case of [heightmaps](https://www.raylib.com/examples/web/models/loader.html?name=models_heightmap).
+raylib provides multiple functions to deal with textures an images, depending on the intended use of the data, user can choose the right one; for example, most of the time, images will be loaded as textures to be displayed on screen but image data can also be used to generate 3d models, like in the case of [heightmaps](https://www.raylib.com/examples/models/loader.html?name=models_heightmap).
 
 To load and draw textures, raylib provides the following functions:
 ```c
@@ -178,8 +178,8 @@ void DrawTexture(Texture2D texture, int posX, int posY, Color tint); // Draw a t
 ```
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [textures_logo_raylib](http://www.raylib.com/examples/web/textures/loader.html?name=textures_logo_raylib) - texture loading and drawing
- - [textures_rectangle](http://www.raylib.com/examples/web/textures/loader.html?name=textures_rectangle) - texture loading and piece drawing
+ - [textures_logo_raylib](http://www.raylib.com/examples/textures/loader.html?name=textures_logo_raylib) - texture loading and drawing
+ - [textures_rectangle](http://www.raylib.com/examples/textures/loader.html?name=textures_rectangle) - texture loading and piece drawing
 
 
 ### Lesson 06: Fonts loading and text drawing
@@ -199,9 +199,9 @@ void DrawTextEx(Font font, const char* text, Vector2 position, int fontSize, int
 ```
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [text_sprite_fonts](http://www.raylib.com/examples/web/text/loader.html?name=text_sprite_fonts) - sprite fonts loading and drawing
- - [text_bmfonts_ttf](http://www.raylib.com/examples/web/text/loader.html?name=text_bmfont_ttf) - bmfonts and ttf fonts loading
- - [text_writing_anim](http://www.raylib.com/examples/web/text/loader.html?name=text_writing_anim) - text writting animation effect
+ - [text_sprite_fonts](http://www.raylib.com/examples/text/loader.html?name=text_sprite_fonts) - sprite fonts loading and drawing
+ - [text_bmfonts_ttf](http://www.raylib.com/examples/text/loader.html?name=text_bmfont_ttf) - bmfonts and ttf fonts loading
+ - [text_writing_anim](http://www.raylib.com/examples/text/loader.html?name=text_writing_anim) - text writting animation effect
 
 
 ### Lesson 07: Sounds and music loading and playing
@@ -236,8 +236,8 @@ void StopMusicStream(Music music);              // Stop music playing
 ```
 
 Recommended [raylib examples](http://www.raylib.com/examples.html) to check:
- - [audio_sound_loading](http://www.raylib.com/examples/web/audio/loader.html?name=audio_sound_loading) - sounds loading and playing
- - [audio_music_stream](http://www.raylib.com/examples/web/audio/loader.html?name=audio_music_stream) - music loading and streaming
+ - [audio_sound_loading](http://www.raylib.com/examples/audio/loader.html?name=audio_sound_loading) - sounds loading and playing
+ - [audio_music_stream](http://www.raylib.com/examples/audio/loader.html?name=audio_music_stream) - music loading and streaming
 
 
 ## Getting help 


### PR DESCRIPTION
Links pointing to each example on the `http://www.raylib.com/examples/...` seems to be broken.